### PR TITLE
Add Armada to SNX v3 release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,12 +97,12 @@ commands:
             GITHUB_TOKEN: $GITHUB_TOKEN
           command: |
             bundle_filename=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
-            echo 'export build_filename=$build_filename' >> "$BASH_ENV"
+            # echo 'export build_filename=$build_filename' >> "$BASH_ENV"
             checksum=$(npx armada-cli bundle checksum $bundle_filename)
-            echo 'export checksum=$checksum' >> "$BASH_ENV"
+            # echo 'export checksum=$checksum' >> "$BASH_ENV"
             checksum_filename=$checksum"_SHA256SUM"
             echo $checksum > $checksum_filename
-            echo 'export checksum_filename=$checksum_filename' >> "$BASH_ENV"
+            # echo 'export checksum_filename=$checksum_filename' >> "$BASH_ENV"
 
             gh release create -R $CIRCLE_REPOSITORY_URL release-1
             gh release upload -R $CIRCLE_REPOSITORY_URL release-1 $bundle_filename

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,9 @@ commands:
             echo $checksum > $checksum_filename
             echo "checksum_filename" $checksum_filename
 
-            gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" release-1
-            gh release upload -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" release-1 $bundle_filename
-            gh release upload -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" release-1 $checksum_filename
+            gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "release-1" release-1
+            gh release upload -R $CIRCLE_REPOSITORY_URL release-1 $bundle_filename
+            gh release upload -R $CIRCLE_REPOSITORY_URL release-1 $checksum_filename
 
       - run:
           name: 'Validations'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,13 +105,13 @@ commands:
             echo $CHECKSUM > $CHECKSUM_FILENAME
             echo 'export CHECKSUM_FILENAME='${CHECKSUM_FILENAME} >> $BASH_ENV
 
-            RELEASE_NAME=armada-release-${CIRCLE_SHA1:0:7}-$(date +%s)
+            RELEASE_NAME=release-armada-$(date '+%Y%m%d')
             echo 'export RELEASE_NAME='${RELEASE_NAME} >> $BASH_ENV
 
       - run:
           name: 'Publish Armada Release to Github with assets'
           command: |
-            gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "${RELEASE_NAME}" ${RELEASE_NAME}
+            gh release create -R $CIRCLE_REPOSITORY_URL --notes-from-tag --title "${RELEASE_NAME}" ${RELEASE_NAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${BUNDLE_FILENAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${CHECKSUM_FILENAME}
 
@@ -119,7 +119,6 @@ commands:
           name: 'Push to Armada'
           command: |
             BUNDLE_URL=$(gh release view -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} --json assets --jq ".assets[] | select(.name == \"${BUNDLE_FILENAME}\") | .url")
-
             npx armada-cli project publish $ARMADA_PROJECT_ID $BUNDLE_URL $CHECKSUM --key=$ARMADA_PRIVATE_KEY
 
 jobs:
@@ -333,6 +332,9 @@ workflows:
                 - master
                 - ipfs-deploy
                 - dm-add-armada
+            tags:
+              only:
+                - release-liquidity-*
       # - liquidity-ipfs:
       #     requires:
       #       - checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,9 +104,9 @@ commands:
             echo $checksum > $checksum_filename
             echo 'export checksum_filename=$checksum_filename' >> "$BASH_ENV"
 
-            gh release create -R $CIRCLE_PROJECT_REPONAME release-1
-            gh release upload -R $CIRCLE_PROJECT_REPONAME release-1 $bundle_filename
-            gh release upload -R $CIRCLE_PROJECT_REPONAME release-1 $checksum_filename
+            gh release create -R $CIRCLE_REPOSITORY_URL release-1
+            gh release upload -R $CIRCLE_REPOSITORY_URL release-1 $bundle_filename
+            gh release upload -R $CIRCLE_REPOSITORY_URL release-1 $checksum_filename
 
       - run:
           name: 'Validations'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ commands:
             echo 'export CHECKSUM_FILENAME=${CHECKSUM_FILENAME}' >> "$BASH_ENV"
 
             RELEASE_NAME=armada-release-$CIRCLE_SHA1
-            echo 'export RELEASE_NAME=$R{ELEASE_NAME}' >> "$BASH_ENV"
+            echo 'export RELEASE_NAME=${RELEASE_NAME}' >> "$BASH_ENV"
 
             DMTEST=hello
             echo 'export DMTEST=${DMTEST}' >> "$BASH_ENV"
@@ -118,6 +118,7 @@ commands:
       - run:
           name: 'Publish Armada Release to Github with assets'
           command: |
+            source "$BASH_ENV"
             printenv | grep -E 'RELEASE_NAME|BUNDLE_FILENAME|CHECKSUM_FILENAME'
             echo $RELEASE_NAME
             gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "${RELEASE_NAME}" ${RELEASE_NAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ workflows:
         - equal: ['skip-tests', << pipeline.git.branch >>]
 
     jobs:
-      - checks
+      # - checks
       # - typecheck
       # - tests
       # - liquidity-cy
@@ -320,7 +320,7 @@ workflows:
       # - combine-coverage:
       #     requires: [tests, liquidity-cy, liquidity-e2e-optimism-mainnet]
       - liquidity-armada:
-          requires:
+          # requires:
             # - checks
             # - typecheck
             # - tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,7 +344,8 @@ workflows:
             #     - ipfs-deploy
             #     - dm-add-armada
             tags:
-              only: ^release-liquidity-.*$
+              only:
+                - /.*/
       # - liquidity-ipfs:
       #     requires:
       #       - checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,7 @@ commands:
           command: |
             BUNDLE_URL=$(gh release view -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} --json assets --jq ".assets[] | select(.name == \"${BUNDLE_FILENAME}\") | .url")
 
-            npx armada-cli project publish $ARMADA_PROJECT_ID $BUNDLE_URL $checksum --key=$ARMADA_PRIVATE_KEY
+            npx armada-cli project publish $ARMADA_PROJECT_ID $BUNDLE_URL $CHECKSUM --key=$ARMADA_PRIVATE_KEY
 
 jobs:
   checks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,8 @@ commands:
       - run:
           name: 'Publish Armada Release to Github with assets'
           command: |
+            printenv | grep -E 'RELEASE_NAME|BUNDLE_FILENAME|CHECKSUM_FILENAME'
+            echo $RELEASE_NAME
             gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "${RELEASE_NAME}" ${RELEASE_NAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${BUNDLE_FILENAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${CHECKSUM_FILENAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,12 +102,13 @@ commands:
             echo $checksum > $checksum_filename
             echo "checksum_filename" $checksum_filename
 
-            gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "release-1" release-1
-            gh release upload -R $CIRCLE_REPOSITORY_URL release-1 $bundle_filename
-            gh release upload -R $CIRCLE_REPOSITORY_URL release-1 $checksum_filename
+            release_name=release-$(date '+%Y-%m-%d')
 
-            bundle_url=$(gh release view -R $GITHUB_REPOSITORY ${{ steps.set_variables.outputs.release_name }} --json assets --jq ".assets[] | select(.name == \"${{ steps.create_release.outputs.bundle_filename }}\") | .url")
+            gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "$release_name" $release_name
+            gh release upload -R $CIRCLE_REPOSITORY_URL $release_name $bundle_filename
+            gh release upload -R $CIRCLE_REPOSITORY_URL $release_name $checksum_filename
 
+            bundle_url=$(gh release view -R $CIRCLE_REPOSITORY_URL $release_name --json assets --jq ".assets[] | select(.name == \"$bundle_filename\") | .url")
             echo "bundle url" $bundle_url
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,18 +97,18 @@ commands:
             # new env vars: ARMADA_PROJECT_ID, ARMADA_PRIVATE_KEY, GITHUB_TOKEN
             BUNDLE_FILENAME=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
             echo "BUNDLE_FILENAME" $BUNDLE_FILENAME
-            echo 'export BUNDLE_FILENAME=${BUNDLE_FILENAME}' >> $BASH_ENV
+            echo 'export BUNDLE_FILENAME="${BUNDLE_FILENAME}"' >> $BASH_ENV
 
             CHECKSUM=$(npx armada-cli bundle checksum $BUNDLE_FILENAME)
             echo "CHECKSUM" $CHECKSUM
-            echo 'export CHECKSUM=${CHECKSUM}' >> $BASH_ENV
+            echo 'export CHECKSUM="${CHECKSUM}"' >> $BASH_ENV
 
             CHECKSUM_FILENAME="checksum_SHA256SUM"
             echo $CHECKSUM > $CHECKSUM_FILENAME
-            echo 'export CHECKSUM_FILENAME=${CHECKSUM_FILENAME}' >> $BASH_ENV
+            echo 'export CHECKSUM_FILENAME="${CHECKSUM_FILENAME}"' >> $BASH_ENV
 
             RELEASE_NAME=armada-release-$CIRCLE_SHA1
-            echo 'export RELEASE_NAME=${RELEASE_NAME}' >> $BASH_ENV
+            echo 'export RELEASE_NAME="${RELEASE_NAME}"' >> $BASH_ENV
 
             DMTEST=hello
             echo 'export DMTEST=${DMTEST}' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,8 +336,7 @@ workflows:
             # - liquidity-e2e-optimism-goerli
             # - liquidity-e2e-goerli
           filters:
-            branches:
-              ignore: /.*/
+            # branches:
             #   only:
             #     - release
             #     - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ commands:
             echo "checksum" $checksum
             echo 'export checksum=$checksum' >> "$BASH_ENV"
 
-            checksum_filename=checksum_SHA256SUM"
+            checksum_filename="checksum_SHA256SUM"
             echo $checksum > $checksum_filename
             echo 'export checksum_filename=$checksum_filename' >> "$BASH_ENV"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,28 +97,22 @@ commands:
             # new env vars: ARMADA_PROJECT_ID, ARMADA_PRIVATE_KEY, GITHUB_TOKEN
             BUNDLE_FILENAME=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
             echo "BUNDLE_FILENAME" $BUNDLE_FILENAME
-            echo 'export BUNDLE_FILENAME="${BUNDLE_FILENAME}"' >> $BASH_ENV
+            echo 'export BUNDLE_FILENAME='${BUNDLE_FILENAME} >> $BASH_ENV
 
             CHECKSUM=$(npx armada-cli bundle checksum $BUNDLE_FILENAME)
             echo "CHECKSUM" $CHECKSUM
-            echo 'export CHECKSUM="${CHECKSUM}"' >> $BASH_ENV
+            echo 'export CHECKSUM='${CHECKSUM} >> $BASH_ENV
 
             CHECKSUM_FILENAME="checksum_SHA256SUM"
             echo $CHECKSUM > $CHECKSUM_FILENAME
-            echo 'export CHECKSUM_FILENAME="${CHECKSUM_FILENAME}"' >> $BASH_ENV
+            echo 'export CHECKSUM_FILENAME='${CHECKSUM_FILENAME} >> $BASH_ENV
 
             RELEASE_NAME=armada-release-$CIRCLE_SHA1
-            echo 'export RELEASE_NAME="${RELEASE_NAME}"' >> $BASH_ENV
-
-            DMTEST=hello
-            echo 'export DMTEST=${DMTEST}' >> $BASH_ENV
-            source $BASH_ENV
-            echo $DMTEST
+            echo 'export RELEASE_NAME='${RELEASE_NAME} >> $BASH_ENV
 
       - run:
           name: 'Publish Armada Release to Github with assets'
           command: |
-            source $BASH_ENV
             printenv | grep -E 'RELEASE_NAME|BUNDLE_FILENAME|CHECKSUM_FILENAME'
             echo $RELEASE_NAME
             gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "${RELEASE_NAME}" ${RELEASE_NAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,24 @@ commands:
             curl --silent --request POST --user "$IPFS_USER:$IPFS_PASS" "<< parameters.ipfs-cluster-api >>/pin/add?arg=$IPFS_CID" | tee /tmp/pin-add-$IPFS_CID.log
             cat /tmp/pin-add-$IPFS_CID.log | jq
 
+  armada-deploy:
+    parameters:
+      source-dir:
+        type: string
+    steps:
+      - run:
+          name: 'Install armada-cli'
+          command: |
+            npx armada-cli --version
+
+      - run:
+          name: 'Build armada-cli package'
+          command: |
+            npx armada-cli bundle create armada-bundle "<< parameters.source-dir >>"
+      - run:
+          name: 'Run ls'
+          command: ls
+
 jobs:
   checks:
     working_directory: /tmp/app
@@ -239,6 +257,18 @@ jobs:
           ipfs-cluster-api: 'https://ipfs.synthetix.io/api/v0'
           ipns-key: 'v3.synthetix.eth'
 
+  liquidity-armada:
+    working_directory: /tmp/app
+    docker:
+      - image: cimg/node:<< pipeline.parameters.node-version >>
+    resource_class: large
+    steps:
+      - checkout
+      - yarn-install
+      - run: yarn workspace @snx-v3/liquidity build
+      - armada-deploy:
+          source-dir: './liquidity/ui/dist'
+
 workflows:
   ui:
     unless:
@@ -261,7 +291,7 @@ workflows:
           name: liquidity-e2e-goerli
       - combine-coverage:
           requires: [tests, liquidity-cy, liquidity-e2e-optimism-mainnet]
-      - liquidity-ipfs:
+      - liquidity-armada:
           requires:
             - checks
             - typecheck
@@ -276,3 +306,19 @@ workflows:
                 - release
                 - master
                 - ipfs-deploy
+                - dm-add-armada
+      # - liquidity-ipfs:
+      #     requires:
+      #       - checks
+      #       - typecheck
+      #       - tests
+      #       - liquidity-cy
+      #       - liquidity-e2e-optimism-mainnet
+      #       - liquidity-e2e-optimism-goerli
+      #       - liquidity-e2e-goerli
+      #     filters:
+      #       branches:
+      #         only:
+      #           - release
+      #           - master
+      #           - ipfs-deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,7 +336,8 @@ workflows:
             # - liquidity-e2e-optimism-goerli
             # - liquidity-e2e-goerli
           filters:
-            # branches:
+            branches:
+              ignore: /.*/
             #   only:
             #     - release
             #     - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,34 +95,35 @@ commands:
           name: 'Build armada-cli package'
           command: |
             # new env vars: ARMADA_PROJECT_ID, ARMADA_PRIVATE_KEY, GITHUB_TOKEN
-            bundle_filename=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
-            echo "bundle_filename" $bundle_filename
-            echo 'export bundle_filename=$bundle_filename' >> "$BASH_ENV"
+            BUNDLE_FILENAME=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
+            echo "BUNDLE_FILENAME" $BUNDLE_FILENAME
+            echo 'export BUNDLE_FILENAME=$BUNDLE_FILENAME' >> "$BASH_ENV"
 
-            checksum=$(npx armada-cli bundle checksum $bundle_filename)
-            echo "checksum" $checksum
-            echo 'export checksum=$checksum' >> "$BASH_ENV"
+            CHECKSUM=$(npx armada-cli bundle CHECKSUM $BUNDLE_FILENAME)
+            echo "CHECKSUM" $CHECKSUM
+            echo 'export CHECKSUM=$CHECKSUM' >> "$BASH_ENV"
 
-            checksum_filename="checksum_SHA256SUM"
-            echo $checksum > $checksum_filename
-            echo 'export checksum_filename=$checksum_filename' >> "$BASH_ENV"
+            CHECKSUM_FILENAME="checksum_SHA256SUM"
+            echo $CHECKSUM > $CHECKSUM_FILENAME
+            echo 'export CHECKSUM_FILENAME=$CHECKSUM_FILENAME' >> "$BASH_ENV"
 
-            release_name=armada-release-$CIRCLE_SHA1
+            RELEASE_NAME=armada-release-$CIRCLE_SHA1
+            echo 'export RELEASE_NAME=$RELEASE_NAME' >> "$BASH_ENV"
 
       - run:
           name: 'Publish Armada Release to Github with assets'
           command: |
-            gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "$release_name" $release_name
-            gh release upload -R $CIRCLE_REPOSITORY_URL $release_name $bundle_filename
-            gh release upload -R $CIRCLE_REPOSITORY_URL $release_name $checksum_filename
+            gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "${RELEASE_NAME}" ${RELEASE_NAME}
+            gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${BUNDLE_FILENAME}
+            gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${CHECKSUM_FILENAME}
 
       - run:
           name: 'Push to Armada'
           command: |
-            bundle_url=$(gh release view -R $CIRCLE_REPOSITORY_URL $release_name --json assets --jq ".assets[] | select(.name == \"$bundle_filename\") | .url")
-            echo "bundle url" $bundle_url
+            BUNDLE_URL=$(gh release view -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} --json assets --jq ".assets[] | select(.name == \"${BUNDLE_FILENAME}\") | .url")
+            echo "bundle url" $BUNDLE_URL
 
-            # npx armada-cli project publish $ARMADA_PROJECT_ID $bundle_url $checksum --key=$ARMADA_PRIVATE_KEY
+            # npx armada-cli project publish $ARMADA_PROJECT_ID $BUNDLE_URL $checksum --key=$ARMADA_PRIVATE_KEY
 
 jobs:
   checks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 orbs:
-  github-cli: circleci/github-cli@2.2.0
-
+  gh: circleci/github-cli@2.2.0
 
 parameters:
   node-version:
@@ -96,12 +95,13 @@ commands:
           name: 'Build armada-cli package'
           command: |
             bundle_filename=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
+            echo "bundle filename" $bundle_filename
             checksum=$(npx armada bundle checksum $bundle_filename)
-            echo $checksum
+            echo "checksum" $checksum
             checksum_filename=$checksum"_SHA256SUM"
-            echo $checksum_filename
+            echo "checksum_filename" $checksum_filename
             echo $checksum > $checksum_filename
-            echo $checksum_filename
+            cat $checksum_filename
 
       - run:
           name: 'Validations'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,29 +94,35 @@ commands:
       - run:
           name: 'Build armada-cli package'
           command: |
+            # new env vars: ARMADA_PROJECT_ID, ARMADA_PRIVATE_KEY, GITHUB_TOKEN
             bundle_filename=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
             echo "bundle_filename" $bundle_filename
+            echo 'export bundle_filename=$bundle_filename' >> "$BASH_ENV"
+
             checksum=$(npx armada-cli bundle checksum $bundle_filename)
             echo "checksum" $checksum
-            checksum_filename=$checksum"_SHA256SUM"
+            echo 'export checksum=$checksum' >> "$BASH_ENV"
+
+            checksum_filename=checksum_SHA256SUM"
             echo $checksum > $checksum_filename
-            echo "checksum_filename" $checksum_filename
+            echo 'export checksum_filename=$checksum_filename' >> "$BASH_ENV"
 
-            release_name=release-$(date '+%Y-%m-%d')
+            release_name=armada-release-$CIRCLE_SHA1
 
+      - run:
+          name: 'Publish Armada Release to Github with assets'
+          command: |
             gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "$release_name" $release_name
             gh release upload -R $CIRCLE_REPOSITORY_URL $release_name $bundle_filename
             gh release upload -R $CIRCLE_REPOSITORY_URL $release_name $checksum_filename
 
+      - run:
+          name: 'Push to Armada'
+          command: |
             bundle_url=$(gh release view -R $CIRCLE_REPOSITORY_URL $release_name --json assets --jq ".assets[] | select(.name == \"$bundle_filename\") | .url")
             echo "bundle url" $bundle_url
 
-      - run:
-          name: 'Validations'
-          command: |
-            ls
-            pwd
-            gh
+            # npx armada-cli project publish $ARMADA_PROJECT_ID $bundle_url $checksum --key=$ARMADA_PRIVATE_KEY
 
 jobs:
   checks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,15 +93,20 @@ commands:
 
       - run:
           name: 'Build armada-cli package'
+          environment:
+            GITHUB_TOKEN: $GITHUB_TOKEN
           command: |
             bundle_filename=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
-            echo "bundle filename" $bundle_filename
-            checksum=$(npx armada bundle checksum $bundle_filename)
-            echo "checksum" $checksum
+            echo 'export build_filename=$build_filename' >> "$BASH_ENV"
+            checksum=$(npx armada-cli bundle checksum $bundle_filename)
+            echo 'export checksum=$checksum' >> "$BASH_ENV"
             checksum_filename=$checksum"_SHA256SUM"
-            echo "checksum_filename" $checksum_filename
             echo $checksum > $checksum_filename
-            cat $checksum_filename
+            echo 'export checksum_filename=$checksum_filename' >> "$BASH_ENV"
+
+            gh release create -R $CIRCLE_PROJECT_REPONAME release-1
+            gh release upload -R $CIRCLE_PROJECT_REPONAME release-1 $bundle_filename
+            gh release upload -R $CIRCLE_PROJECT_REPONAME release-1 $checksum_filename
 
       - run:
           name: 'Validations'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,7 +334,7 @@ workflows:
                 - dm-add-armada
             tags:
               only:
-                - release-liquidity-.*
+                - /release-liquidity-.*/
       # - liquidity-ipfs:
       #     requires:
       #       - checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
 version: 2.1
-orbs:
-  gh: circleci/github-cli@2.2.0
 
 parameters:
   node-version:
@@ -85,20 +83,18 @@ commands:
       source-dir:
         type: string
     steps:
-      - gh/install
       - run:
           name: 'Install armada-cli and dependencies'
           command: |
             sudo apt-get update && sudo apt-get install -y libusb-1.0 libudev-dev libsecret-1-dev
 
             # gh cli
-            # type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
-            # curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-            # && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
-            # && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-            # && sudo apt update \
-            # && sudo apt install gh -y
-
+            type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+            && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+            && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+            && sudo apt update \
+            && sudo apt install gh -y
             
             npx armada-cli --version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ commands:
             echo $CHECKSUM > $CHECKSUM_FILENAME
             echo 'export CHECKSUM_FILENAME='${CHECKSUM_FILENAME} >> $BASH_ENV
 
-            RELEASE_NAME=armada-release-${CIRCLE_SHA1:0:7}
+            RELEASE_NAME=armada-release-${CIRCLE_SHA1:0:7}-$(date +%s)
             echo 'export RELEASE_NAME='${RELEASE_NAME} >> $BASH_ENV
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,27 +94,22 @@ commands:
       - run:
           name: 'Build Armada bundle'
           command: |
-            # new env vars: ARMADA_PROJECT_ID, ARMADA_PRIVATE_KEY, GITHUB_TOKEN
             BUNDLE_FILENAME=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
-            echo "BUNDLE_FILENAME" $BUNDLE_FILENAME
             echo 'export BUNDLE_FILENAME='${BUNDLE_FILENAME} >> $BASH_ENV
 
             CHECKSUM=$(npx armada-cli bundle checksum $BUNDLE_FILENAME)
-            echo "CHECKSUM" $CHECKSUM
             echo 'export CHECKSUM='${CHECKSUM} >> $BASH_ENV
 
             CHECKSUM_FILENAME="checksum_SHA256SUM"
             echo $CHECKSUM > $CHECKSUM_FILENAME
             echo 'export CHECKSUM_FILENAME='${CHECKSUM_FILENAME} >> $BASH_ENV
 
-            RELEASE_NAME=armada-release-$CIRCLE_SHA1
+            RELEASE_NAME=armada-release-${CIRCLE_SHA1:0:7}
             echo 'export RELEASE_NAME='${RELEASE_NAME} >> $BASH_ENV
 
       - run:
           name: 'Publish Armada Release to Github with assets'
           command: |
-            printenv | grep -E 'RELEASE_NAME|BUNDLE_FILENAME|CHECKSUM_FILENAME'
-            echo $RELEASE_NAME
             gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "${RELEASE_NAME}" ${RELEASE_NAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${BUNDLE_FILENAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${CHECKSUM_FILENAME}
@@ -123,7 +118,6 @@ commands:
           name: 'Push to Armada'
           command: |
             BUNDLE_URL=$(gh release view -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} --json assets --jq ".assets[] | select(.name == \"${BUNDLE_FILENAME}\") | .url")
-            echo "bundle url" $BUNDLE_URL
 
             # npx armada-cli project publish $ARMADA_PROJECT_ID $BUNDLE_URL $checksum --key=$ARMADA_PRIVATE_KEY
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ commands:
       - run:
           name: 'Publish Armada Release to Github with assets'
           command: |
-            gh release create -R $CIRCLE_REPOSITORY_URL --notes "" --title "${RELEASE_NAME}" ${RELEASE_NAME}
+            gh release create -R $CIRCLE_REPOSITORY_URL --generate-notes --title "${RELEASE_NAME}" ${RELEASE_NAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${BUNDLE_FILENAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${CHECKSUM_FILENAME}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ commands:
           command: |
             BUNDLE_URL=$(gh release view -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} --json assets --jq ".assets[] | select(.name == \"${BUNDLE_FILENAME}\") | .url")
 
-            # npx armada-cli project publish $ARMADA_PROJECT_ID $BUNDLE_URL $checksum --key=$ARMADA_PRIVATE_KEY
+            npx armada-cli project publish $ARMADA_PROJECT_ID $BUNDLE_URL $checksum --key=$ARMADA_PRIVATE_KEY
 
 jobs:
   checks:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,16 @@ commands:
           name: 'Install armada-cli and dependencies'
           command: |
             sudo apt-get update && sudo apt-get install -y libusb-1.0 libudev-dev libsecret-1-dev
+
+            # gh cli
+            # type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+            # curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+            # && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+            # && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+            # && sudo apt update \
+            # && sudo apt install gh -y
+
+            
             npx armada-cli --version
 
       - run:
@@ -326,12 +336,12 @@ workflows:
             # - liquidity-e2e-optimism-goerli
             # - liquidity-e2e-goerli
           filters:
-            branches:
-              only:
-                - release
-                - master
-                - ipfs-deploy
-                - dm-add-armada
+            # branches:
+            #   only:
+            #     - release
+            #     - master
+            #     - ipfs-deploy
+            #     - dm-add-armada
             tags:
               only: ^release-liquidity-.*$
       # - liquidity-ipfs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
       - run:
           name: 'Publish Armada Release to Github with assets'
           command: |
-            gh release create -R $CIRCLE_REPOSITORY_URL --generate-notes --title "${RELEASE_NAME}" ${RELEASE_NAME}
+            gh release create -R $CIRCLE_REPOSITORY_URL --notes "" --title "${RELEASE_NAME}" ${RELEASE_NAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${BUNDLE_FILENAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${CHECKSUM_FILENAME}
 
@@ -333,8 +333,7 @@ workflows:
                 - ipfs-deploy
                 - dm-add-armada
             tags:
-              only:
-                - /release-liquidity-.*/
+              only: ^release-liquidity-.*$
       # - liquidity-ipfs:
       #     requires:
       #       - checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,10 @@ commands:
             gh release upload -R $CIRCLE_REPOSITORY_URL release-1 $bundle_filename
             gh release upload -R $CIRCLE_REPOSITORY_URL release-1 $checksum_filename
 
+            bundle_url=$(gh release view -R $GITHUB_REPOSITORY ${{ steps.set_variables.outputs.release_name }} --json assets --jq ".assets[] | select(.name == \"${{ steps.create_release.outputs.bundle_filename }}\") | .url")
+
+            echo "bundle url" $bundle_url
+
       - run:
           name: 'Validations'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,6 @@ workflows:
                 - release
                 - master
                 - ipfs-deploy
-                - dm-add-armada
       - liquidity-ipfs:
           requires:
             - checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ commands:
             && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
             && sudo apt update \
             && sudo apt install gh -y
-            
+
             # check that armada-cli runs
             npx armada-cli --version
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,18 +97,23 @@ commands:
             # new env vars: ARMADA_PROJECT_ID, ARMADA_PRIVATE_KEY, GITHUB_TOKEN
             BUNDLE_FILENAME=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
             echo "BUNDLE_FILENAME" $BUNDLE_FILENAME
-            echo 'export BUNDLE_FILENAME=$BUNDLE_FILENAME' >> "$BASH_ENV"
+            echo 'export BUNDLE_FILENAME=${BUNDLE_FILENAME}' >> "$BASH_ENV"
 
             CHECKSUM=$(npx armada-cli bundle checksum $BUNDLE_FILENAME)
             echo "CHECKSUM" $CHECKSUM
-            echo 'export CHECKSUM=$CHECKSUM' >> "$BASH_ENV"
+            echo 'export CHECKSUM=${CHECKSUM}' >> "$BASH_ENV"
 
             CHECKSUM_FILENAME="checksum_SHA256SUM"
             echo $CHECKSUM > $CHECKSUM_FILENAME
-            echo 'export CHECKSUM_FILENAME=$CHECKSUM_FILENAME' >> "$BASH_ENV"
+            echo 'export CHECKSUM_FILENAME=${CHECKSUM_FILENAME}' >> "$BASH_ENV"
 
             RELEASE_NAME=armada-release-$CIRCLE_SHA1
-            echo 'export RELEASE_NAME=$RELEASE_NAME' >> "$BASH_ENV"
+            echo 'export RELEASE_NAME=$R{ELEASE_NAME}' >> "$BASH_ENV"
+
+            DMTEST=hello
+            echo 'export DMTEST=${DMTEST}' >> "$BASH_ENV"
+            source "$BASH_ENV"
+            echo $DMTEST
 
       - run:
           name: 'Publish Armada Release to Github with assets'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,16 +97,16 @@ commands:
             GITHUB_TOKEN: $GITHUB_TOKEN
           command: |
             bundle_filename=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
-            # echo 'export build_filename=$build_filename' >> "$BASH_ENV"
+            echo "bundle_filename" $bundle_filename
             checksum=$(npx armada-cli bundle checksum $bundle_filename)
-            # echo 'export checksum=$checksum' >> "$BASH_ENV"
+            echo "checksum" $checksum
             checksum_filename=$checksum"_SHA256SUM"
             echo $checksum > $checksum_filename
-            # echo 'export checksum_filename=$checksum_filename' >> "$BASH_ENV"
+            echo "checksum_filename" $checksum_filename
 
-            gh release create -R $CIRCLE_REPOSITORY_URL release-1
-            gh release upload -R $CIRCLE_REPOSITORY_URL release-1 $bundle_filename
-            gh release upload -R $CIRCLE_REPOSITORY_URL release-1 $checksum_filename
+            gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" release-1
+            gh release upload -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" release-1 $bundle_filename
+            gh release upload -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" release-1 $checksum_filename
 
       - run:
           name: 'Validations'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,15 +336,12 @@ workflows:
             # - liquidity-e2e-optimism-goerli
             # - liquidity-e2e-goerli
           filters:
-            # branches:
-            #   only:
-            #     - release
-            #     - master
-            #     - ipfs-deploy
-            #     - dm-add-armada
-            tags:
+            branches:
               only:
-                - /.*/
+                - release
+                - master
+                - ipfs-deploy
+                # - dm-add-armada
       # - liquidity-ipfs:
       #     requires:
       #       - checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,11 +84,12 @@ commands:
         type: string
     steps:
       - run:
-          name: 'Install armada-cli and dependencies'
+          name: 'Install dependencies'
           command: |
+            # dependencies for armada-cli
             sudo apt-get update && sudo apt-get install -y libusb-1.0 libudev-dev libsecret-1-dev
 
-            # gh cli
+            # gh cli, the github org is several minor versions behind
             type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
             curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
             && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
@@ -96,6 +97,7 @@ commands:
             && sudo apt update \
             && sudo apt install gh -y
             
+            # check that armada-cli runs
             npx armada-cli --version
 
       - run:
@@ -307,30 +309,30 @@ workflows:
         - equal: ['skip-tests', << pipeline.git.branch >>]
 
     jobs:
-      # - checks
-      # - typecheck
-      # - tests
-      # - liquidity-cy
-      # - liquidity-e2e:
-      #     chain: optimism-mainnet
-      #     name: liquidity-e2e-optimism-mainnet
-      # - liquidity-e2e:
-      #     chain: optimism-goerli
-      #     name: liquidity-e2e-optimism-goerli
-      # - liquidity-e2e:
-      #     chain: goerli
-      #     name: liquidity-e2e-goerli
-      # - combine-coverage:
-      #     requires: [tests, liquidity-cy, liquidity-e2e-optimism-mainnet]
+      - checks
+      - typecheck
+      - tests
+      - liquidity-cy
+      - liquidity-e2e:
+          chain: optimism-mainnet
+          name: liquidity-e2e-optimism-mainnet
+      - liquidity-e2e:
+          chain: optimism-goerli
+          name: liquidity-e2e-optimism-goerli
+      - liquidity-e2e:
+          chain: goerli
+          name: liquidity-e2e-goerli
+      - combine-coverage:
+          requires: [tests, liquidity-cy, liquidity-e2e-optimism-mainnet]
       - liquidity-armada:
-          # requires:
-            # - checks
-            # - typecheck
-            # - tests
-            # - liquidity-cy
-            # - liquidity-e2e-optimism-mainnet
-            # - liquidity-e2e-optimism-goerli
-            # - liquidity-e2e-goerli
+          requires:
+            - checks
+            - typecheck
+            - tests
+            - liquidity-cy
+            - liquidity-e2e-optimism-mainnet
+            - liquidity-e2e-optimism-goerli
+            - liquidity-e2e-goerli
           filters:
             branches:
               only:
@@ -338,18 +340,18 @@ workflows:
                 - master
                 - ipfs-deploy
                 - dm-add-armada
-      # - liquidity-ipfs:
-      #     requires:
-      #       - checks
-      #       - typecheck
-      #       - tests
-      #       - liquidity-cy
-      #       - liquidity-e2e-optimism-mainnet
-      #       - liquidity-e2e-optimism-goerli
-      #       - liquidity-e2e-goerli
-      #     filters:
-      #       branches:
-      #         only:
-      #           - release
-      #           - master
-      #           - ipfs-deploy
+      - liquidity-ipfs:
+          requires:
+            - checks
+            - typecheck
+            - tests
+            - liquidity-cy
+            - liquidity-e2e-optimism-mainnet
+            - liquidity-e2e-optimism-goerli
+            - liquidity-e2e-goerli
+          filters:
+            branches:
+              only:
+                - release
+                - master
+                - ipfs-deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,33 +92,33 @@ commands:
             npx armada-cli --version
 
       - run:
-          name: 'Build armada-cli package'
+          name: 'Build Armada bundle'
           command: |
             # new env vars: ARMADA_PROJECT_ID, ARMADA_PRIVATE_KEY, GITHUB_TOKEN
             BUNDLE_FILENAME=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
             echo "BUNDLE_FILENAME" $BUNDLE_FILENAME
-            echo 'export BUNDLE_FILENAME=${BUNDLE_FILENAME}' >> "$BASH_ENV"
+            echo 'export BUNDLE_FILENAME=${BUNDLE_FILENAME}' >> $BASH_ENV
 
             CHECKSUM=$(npx armada-cli bundle checksum $BUNDLE_FILENAME)
             echo "CHECKSUM" $CHECKSUM
-            echo 'export CHECKSUM=${CHECKSUM}' >> "$BASH_ENV"
+            echo 'export CHECKSUM=${CHECKSUM}' >> $BASH_ENV
 
             CHECKSUM_FILENAME="checksum_SHA256SUM"
             echo $CHECKSUM > $CHECKSUM_FILENAME
-            echo 'export CHECKSUM_FILENAME=${CHECKSUM_FILENAME}' >> "$BASH_ENV"
+            echo 'export CHECKSUM_FILENAME=${CHECKSUM_FILENAME}' >> $BASH_ENV
 
             RELEASE_NAME=armada-release-$CIRCLE_SHA1
-            echo 'export RELEASE_NAME=${RELEASE_NAME}' >> "$BASH_ENV"
+            echo 'export RELEASE_NAME=${RELEASE_NAME}' >> $BASH_ENV
 
             DMTEST=hello
-            echo 'export DMTEST=${DMTEST}' >> "$BASH_ENV"
-            source "$BASH_ENV"
+            echo 'export DMTEST=${DMTEST}' >> $BASH_ENV
+            source $BASH_ENV
             echo $DMTEST
 
       - run:
           name: 'Publish Armada Release to Github with assets'
           command: |
-            source "$BASH_ENV"
+            source $BASH_ENV
             printenv | grep -E 'RELEASE_NAME|BUNDLE_FILENAME|CHECKSUM_FILENAME'
             echo $RELEASE_NAME
             gh release create -R $CIRCLE_REPOSITORY_URL --notes "Armada 1.0.0" --title "${RELEASE_NAME}" ${RELEASE_NAME}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,8 +87,9 @@ commands:
     steps:
       - gh/install
       - run:
-          name: 'Install armada-cli'
+          name: 'Install armada-cli and dependencies'
           command: |
+            sudo apt-get update && sudo apt-get install -y libusb-1.0 libudev-dev libsecret-1-dev
             npx armada-cli --version
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,10 +91,20 @@ commands:
       - run:
           name: 'Build armada-cli package'
           command: |
-            npx armada-cli bundle create armada-bundle "<< parameters.source-dir >>"
+            bundle_filename=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
+            checksum="$(npx armada bundle checksum $bundle_filename)"
+            echo $checksum
+            checksum_filename=$checksum"_SHA256SUM"
+            echo $checksum_filename
+            echo $checksum > $checksum_filename
+            echo $checksum_filename
+
       - run:
-          name: 'Run ls'
-          command: ls
+          name: 'Validations'
+          command: |
+            ls
+            pwd
+            gh
 
 jobs:
   checks:
@@ -277,29 +287,29 @@ workflows:
 
     jobs:
       - checks
-      - typecheck
-      - tests
-      - liquidity-cy
-      - liquidity-e2e:
-          chain: optimism-mainnet
-          name: liquidity-e2e-optimism-mainnet
-      - liquidity-e2e:
-          chain: optimism-goerli
-          name: liquidity-e2e-optimism-goerli
-      - liquidity-e2e:
-          chain: goerli
-          name: liquidity-e2e-goerli
-      - combine-coverage:
-          requires: [tests, liquidity-cy, liquidity-e2e-optimism-mainnet]
+      # - typecheck
+      # - tests
+      # - liquidity-cy
+      # - liquidity-e2e:
+      #     chain: optimism-mainnet
+      #     name: liquidity-e2e-optimism-mainnet
+      # - liquidity-e2e:
+      #     chain: optimism-goerli
+      #     name: liquidity-e2e-optimism-goerli
+      # - liquidity-e2e:
+      #     chain: goerli
+      #     name: liquidity-e2e-goerli
+      # - combine-coverage:
+      #     requires: [tests, liquidity-cy, liquidity-e2e-optimism-mainnet]
       - liquidity-armada:
           requires:
             - checks
-            - typecheck
-            - tests
-            - liquidity-cy
-            - liquidity-e2e-optimism-mainnet
-            - liquidity-e2e-optimism-goerli
-            - liquidity-e2e-goerli
+            # - typecheck
+            # - tests
+            # - liquidity-cy
+            # - liquidity-e2e-optimism-mainnet
+            # - liquidity-e2e-optimism-goerli
+            # - liquidity-e2e-goerli
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,8 +93,6 @@ commands:
 
       - run:
           name: 'Build armada-cli package'
-          environment:
-            GITHUB_TOKEN: $GITHUB_TOKEN
           command: |
             bundle_filename=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
             echo "bundle_filename" $bundle_filename
@@ -312,7 +310,7 @@ workflows:
       #     requires: [tests, liquidity-cy, liquidity-e2e-optimism-mainnet]
       - liquidity-armada:
           requires:
-            - checks
+            # - checks
             # - typecheck
             # - tests
             # - liquidity-cy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ workflows:
                 - release
                 - master
                 - ipfs-deploy
-                # - dm-add-armada
+                - dm-add-armada
       # - liquidity-ipfs:
       #     requires:
       #       - checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ commands:
       - run:
           name: 'Publish Armada Release to Github with assets'
           command: |
-            gh release create -R $CIRCLE_REPOSITORY_URL --notes-from-tag --title "${RELEASE_NAME}" ${RELEASE_NAME}
+            gh release create -R $CIRCLE_REPOSITORY_URL --generate-notes --title "${RELEASE_NAME}" ${RELEASE_NAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${BUNDLE_FILENAME}
             gh release upload -R $CIRCLE_REPOSITORY_URL ${RELEASE_NAME} ${CHECKSUM_FILENAME}
 
@@ -334,7 +334,7 @@ workflows:
                 - dm-add-armada
             tags:
               only:
-                - release-liquidity-*
+                - release-liquidity-.*
       # - liquidity-ipfs:
       #     requires:
       #       - checks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ commands:
             echo "BUNDLE_FILENAME" $BUNDLE_FILENAME
             echo 'export BUNDLE_FILENAME=$BUNDLE_FILENAME' >> "$BASH_ENV"
 
-            CHECKSUM=$(npx armada-cli bundle CHECKSUM $BUNDLE_FILENAME)
+            CHECKSUM=$(npx armada-cli bundle checksum $BUNDLE_FILENAME)
             echo "CHECKSUM" $CHECKSUM
             echo 'export CHECKSUM=$CHECKSUM' >> "$BASH_ENV"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
 version: 2.1
+orbs:
+  github-cli: circleci/github-cli@2.2.0
+
 
 parameters:
   node-version:
@@ -83,6 +86,7 @@ commands:
       source-dir:
         type: string
     steps:
+      - gh/install
       - run:
           name: 'Install armada-cli'
           command: |
@@ -92,7 +96,7 @@ commands:
           name: 'Build armada-cli package'
           command: |
             bundle_filename=$(npx armada-cli bundle create armada-bundle-liquidity "<< parameters.source-dir >>")
-            checksum="$(npx armada bundle checksum $bundle_filename)"
+            checksum=$(npx armada bundle checksum $bundle_filename)
             echo $checksum
             checksum_filename=$checksum"_SHA256SUM"
             echo $checksum_filename


### PR DESCRIPTION
This workflow kicks off exactly the same as liquidity-ipfs, there's room to customize and add other triggers. The armada-deploy job creates a new github release to publish the armada bundle and checksum assets.

3 new env vars added:
- ARMADA_PROJECT_ID
- ARMADA_PRIVATE_KEY
- GITHUB_TOKEN 